### PR TITLE
Add Version into Info while creating SwaggerDoc

### DIFF
--- a/src/Api.Sample.Template.WebApi/Server/Startup.cs
+++ b/src/Api.Sample.Template.WebApi/Server/Startup.cs
@@ -46,7 +46,7 @@ namespace Api.Sample.Template.WebApi.Server
             
             services.AddSwaggerGen(s =>
             {
-                s.SwaggerDoc("v1", new Info { Title = "Api.Sample.Template Swagger Documentation" });
+                s.SwaggerDoc("v1", new Info { Title = "Api.Sample.Template Swagger Documentation", Version = "1.0.0" });
             });
         }
 


### PR DESCRIPTION
Version information is mandatory to create an API on Azure API Management